### PR TITLE
Minor changes to improve performance

### DIFF
--- a/MbCache/Configuration/CacheKeyBase.cs
+++ b/MbCache/Configuration/CacheKeyBase.cs
@@ -46,31 +46,33 @@ namespace MbCache.Configuration
 			return string.Concat(RemoveKey(type), separator, component.UniqueId);
 		}
 
-		public string RemoveKey(ComponentType type, ICachingComponent component, MethodInfo method)
+		public string RemoveKey(ComponentType type, ICachingComponent component, MethodInfo method, IEnumerable<object> parameters = null)
 		{
 			var ret = new StringBuilder(RemoveKey(type, component));
-			ret.Append(separator);
-			ret.Append(method.Name);
-			foreach (var parameter in method.GetParameters())
-			{
-				ret.Append(separatorForParameters);
-				ret.Append(parameter.ParameterType);
-			}
-			return ret.ToString();
-		}
 
-		public string RemoveKey(ComponentType type, ICachingComponent component, MethodInfo method, IEnumerable<object> parameters)
-		{
-			var ret = new StringBuilder(RemoveKey(type, component, method));
-			ret.Append(separator);
-			foreach (var parameter in parameters)
+			if (method != null)
 			{
-				ret.Append(separatorForParameters);
-				var parameterKey = ParameterValue(parameter);
-				if (parameterKey == null)
-					return null;
-				checkIfSuspiousParameter(parameter, parameterKey);
-				ret.Append(parameterKey);
+				ret.Append(separator);
+				ret.Append(method.Name);
+				foreach (var parameter in method.GetParameters())
+				{
+					ret.Append(separatorForParameters);
+					ret.Append(parameter.ParameterType);
+				}
+			}
+
+			if (parameters != null)
+			{
+				ret.Append(separator);
+				foreach (var parameter in parameters)
+				{
+					ret.Append(separatorForParameters);
+					var parameterKey = ParameterValue(parameter);
+					if (parameterKey == null)
+						return null;
+					checkIfSuspiousParameter(parameter, parameterKey);
+					ret.Append(parameterKey);
+				}
 			}
 
 			return ret.ToString();
@@ -85,16 +87,14 @@ namespace MbCache.Configuration
 			var scope = Scope();
 			var completeKey = scope == null ? 
 				startKey : 
-				string.Concat(startKey, separator, Scope());
+				string.Concat(startKey, separator, scope);
 			return new KeyAndItsDependingKeys(completeKey, () => allRemoveKeys(completeKey));
 		}
 
 		private static IEnumerable<string> allRemoveKeys(string getAndPutKey)
 		{
-			var keys = new List<string>();
 			var matches = findSeperator.Matches(getAndPutKey);
-			keys.AddRange(from Match match in matches select getAndPutKey.Substring(0, match.Index));
-			return keys;
+			return from Match match in matches select getAndPutKey.Substring(0, match.Index);
 		}
 
 		private void checkIfSuspiousParameter(object parameter, string parameterKey)

--- a/MbCache/Configuration/FixedNumberOfLockObjects.cs
+++ b/MbCache/Configuration/FixedNumberOfLockObjects.cs
@@ -14,7 +14,7 @@ namespace MbCache.Configuration
 
 		public FixedNumberOfLockObjects(int spread)
 		{
-			_lockobjects = Enumerable.Range(0, spread)
+			_lockobjects = Enumerable.Repeat(0, spread)
 				.Select(x => new object())
 				.ToArray();
 		}

--- a/MbCache/Configuration/ICacheKey.cs
+++ b/MbCache/Configuration/ICacheKey.cs
@@ -54,25 +54,7 @@ namespace MbCache.Configuration
 		/// A string representation of the component.
 		/// </returns>
 		string RemoveKey(ComponentType type, ICachingComponent component);
-
-		/// <summary>
-		/// Creates a cache key for a specific method.
-		/// </summary>
-		/// <param name="type">Type of the component</param>
-		/// <param name="component">
-		/// The component instance.
-		/// </param>
-		/// <param name="method">
-		/// The method of the component.
-		/// </param>
-		/// <remarks>
-		/// Used by MbCache when invalidating all cache entries for a specific method.
-		/// </remarks>
-		/// <returns>
-		/// A string representation of the method.
-		/// </returns>
-		string RemoveKey(ComponentType type, ICachingComponent component, MethodInfo method);
-
+		
 		/// <summary>
 		/// Creates a cache key for a specific component with specific parameters.
 		/// </summary>
@@ -95,7 +77,7 @@ namespace MbCache.Configuration
 		/// Null is returned if the method is configured but with these specific parameters
 		/// shouldn't be invalidated from the cache.
 		/// </returns>
-		string RemoveKey(ComponentType type, ICachingComponent component, MethodInfo method, IEnumerable<object> parameters);
+		string RemoveKey(ComponentType type, ICachingComponent component, MethodInfo method, IEnumerable<object> parameters = null);
 
 		/// <summary>
 		/// Creates a cache key for a specific component with specific parameters.


### PR DESCRIPTION
Merge two RemoveKey calls into one to avoid duplicate StringBuilder
instances in frequent use case
Use local scope variable instead of creating new
Use .Repeat instead if .Range as numeric value is ignored