### PR TITLE
New parameters CacheKey type for handling Suspicious parameters

### DIFF
--- a/MbCache/Configuration/CacheKeyBase.cs
+++ b/MbCache/Configuration/CacheKeyBase.cs
@@ -61,7 +61,7 @@ namespace MbCache.Configuration
 				var parameterKey = ParameterValue(parameter);
 				if (parameterKey == null)
 					return null;
-				checkIfSuspiousParameter(parameter, parameterKey);
+				checkIfSuspiciousParameter(parameter, parameterKey);
 				ret.Append(parameterKey);
 			}
 
@@ -100,19 +100,32 @@ namespace MbCache.Configuration
 			return from Match match in matches select getAndPutKey.Substring(0, match.Index);
 		}
 
-		private void checkIfSuspiousParameter(object parameter, string parameterKey)
+		/// <summary>
+		/// Add a warning to the <see cref="IEventListener"/>s when parameters is suspicious (<see cref="parameterIsSuspicious"/>)
+		/// </summary>
+		private void checkIfSuspiciousParameter(object parameter, string parameterKey)
+		{
+			if (parameterIsSuspicious(parameter, parameterKey))
+			{
+				var warningMsg = string.Format(suspisiousParam, parameter.GetType());
+				foreach (var eventListener in _eventListeners)
+				{
+					eventListener.Warning(warningMsg);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Parameter is suspicious when his key value equals his type's name
+		/// </summary>
+		protected bool parameterIsSuspicious(object parameter, string parameterKey)
 		{
 			if (parameter != null)
 			{
 				var parameterType = parameter.GetType();
-				if (parameterKey.Equals(parameterType.ToString()))
-				{
-					foreach (var eventListener in _eventListeners)
-					{
-						eventListener.Warning(string.Format(suspisiousParam, parameterType));
-					}
-				}
+				return parameterKey.Equals(parameterType.ToString());
 			}
+			return false;
 		}
 
 		/// <summary>

--- a/MbCache/Configuration/ToStringOrSerializedCacheKey.cs
+++ b/MbCache/Configuration/ToStringOrSerializedCacheKey.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace MbCache.Configuration
+{
+	[Serializable]
+	public class ToStringOrSerializedCacheKey : ToStringCacheKey
+	{
+
+		protected override string ParameterValue(object parameter)
+		{
+			var toStringKey = base.ParameterValue(parameter);
+
+			if (parameterIsSuspicious(parameter, toStringKey))
+				return JsonConvert.SerializeObject(parameter);
+			return toStringKey;
+		}
+	}
+}

--- a/MbCache/MbCache.csproj
+++ b/MbCache/MbCache.csproj
@@ -36,6 +36,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -60,6 +62,10 @@
     <DocumentationFile>bin\Release\MbCache.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -70,6 +76,7 @@
     <Compile Include="Configuration\InMemoryCache.cs" />
     <Compile Include="Configuration\CacheBuilder.cs" />
     <Compile Include="Configuration\KeyAndItsDependingKeys.cs" />
+    <Compile Include="Configuration\ToStringOrSerializedCacheKey.cs" />
     <Compile Include="Core\CachedItem.cs" />
     <Compile Include="Core\Events\EventListenersCallback.cs" />
     <Compile Include="Core\Events\EventInformation.cs" />
@@ -98,6 +105,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="mbcachekey.snk" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
@@ -129,4 +137,11 @@
     </PreBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="..\packages\StrongNamer.0.0.5\build\StrongNamer.targets" Condition="Exists('..\packages\StrongNamer.0.0.5\build\StrongNamer.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\StrongNamer.0.0.5\build\StrongNamer.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\StrongNamer.0.0.5\build\StrongNamer.targets'))" />
+  </Target>
 </Project>

--- a/MbCacheTest/Logic/ToStringOrSerializedCacheKeyTest.cs
+++ b/MbCacheTest/Logic/ToStringOrSerializedCacheKeyTest.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using MbCache.Configuration;
+using MbCache.Core;
+using MbCacheTest.TestData;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+using SharpTestsEx;
+
+namespace MbCacheTest.Logic
+{
+	public class ToStringOrSerializedCacheKeyTest : FullTest
+	{
+		private static readonly IFixture auto = new Fixture();
+		private EventListenerForTest eventListener;
+		private IMbCacheFactory factory;
+
+		public ToStringOrSerializedCacheKeyTest(Type proxyType) : base(proxyType)
+		{
+		}
+
+		[Test]
+		public void ShouldCacheWhenParameterWithSamePropertiesValue()
+		{
+			var svc = factory.Create<IObjectWithParametersOnCachedMethod>();
+			var obj = auto.Create<ObjectWithComplexProperties>();
+			var sameContentObj = DuplicateObj(obj);
+
+			svc.CachedMethod(obj);
+
+			svc.CachedMethod(sameContentObj);
+			eventListener.CacheHits.Should().Not.Be.Empty();
+		}
+
+		[Test]
+		public void ShouldNotCacheWhenDifferentParameterOfSameType()
+		{
+			var svc = factory.Create<IObjectWithParametersOnCachedMethod>();
+			var obj = auto.Create<ObjectWithComplexProperties>();
+			var differentObj = auto.Create<ObjectWithComplexProperties>();
+
+			svc.CachedMethod(obj);
+
+			svc.CachedMethod(differentObj);
+			eventListener.CacheHits.Should().Be.Empty();
+		}
+
+		[Test]
+		public void ShouldNotIssueTypeNameWarningWithThisCacheKey()
+		{
+			var svc = factory.Create<IObjectWithParametersOnCachedMethod>();
+			var obj = auto.Create<ObjectWithComplexProperties>();
+
+			svc.CachedMethod(obj);
+
+			eventListener.Warnings.Should().Be.Empty();
+		}
+
+		[Test]
+		public void ShouldUseSerializedDataWhenToStringIsTypeName()
+		{
+			var svc = factory.Create<IObjectWithParametersOnCachedMethod>();
+			var obj = auto.Create<ObjectWithComplexProperties>();
+
+			svc.CachedMethod(obj);
+
+			svc.CachedMethod(obj);
+			var cacheKey = AssertCacheHasBeenHitFor("CachedMethod");
+			cacheKey.Contains(obj.DoubleProp.ToString(CultureInfo.InvariantCulture)).Should().Be.True();
+			cacheKey.Contains(obj.StringProp).Should().Be.True();
+			obj.GenericListProp.ForEach(x => cacheKey.Contains(x.Thing).Should().Be.True());
+		}
+
+		[Test]
+		public void ShouldUseValueWhenValueTypeParameter()
+		{
+			var svc = factory.Create<IObjectWithParametersOnCachedMethod>();
+
+			svc.CachedMethod("123");
+
+			svc.CachedMethod("123");
+			var cacheKey = AssertCacheHasBeenHitFor("CachedMethod");
+			Console.WriteLine(cacheKey);
+			cacheKey.Contains("123").Should().Be.True();
+		}
+
+		protected override void TestSetup()
+		{
+			base.TestSetup();
+			ConfigureEventListener();
+
+			CacheBuilder
+				.For<ObjectWithParametersOnCachedMethod>()
+				.CacheMethod(c => c.CachedMethod(null))
+				.CacheKey(new ToStringOrSerializedCacheKey())
+				.As<IObjectWithParametersOnCachedMethod>();
+			factory = CacheBuilder.BuildFactory();
+		}
+
+		private static ObjectWithComplexProperties DuplicateObj(ObjectWithComplexProperties obj)
+		{
+			return JsonConvert.DeserializeObject<ObjectWithComplexProperties>(JsonConvert.SerializeObject(obj));
+		}
+
+		private string AssertCacheHasBeenHitFor(string methodName)
+		{
+			eventListener.CacheHits.Should().Have.Count.EqualTo(1);
+			var cachedItem = eventListener.CacheHits.First();
+			cachedItem.EventInformation.Method.Name.Should().Be.EqualTo(methodName);
+			return cachedItem.EventInformation.CacheKey;
+		}
+
+		private void ConfigureEventListener()
+		{
+			eventListener = new EventListenerForTest();
+			CacheBuilder.AddEventListener(eventListener);
+		}
+	}
+}

--- a/MbCacheTest/MbCacheTest.csproj
+++ b/MbCacheTest/MbCacheTest.csproj
@@ -55,8 +55,16 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.5.0\lib\net40\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Ploeh.AutoFixture, Version=3.50.2.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.3.50.2\lib\net40\Ploeh.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SharpTestsEx, Version=1.1.1.0, Culture=neutral, PublicKeyToken=8c60d8070630b1c1, processorArchitecture=MSIL">
@@ -66,7 +74,12 @@
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
+    <Reference Include="System.Data" />
     <Reference Include="System.Runtime.Caching" />
+    <Reference Include="Z.ExtensionMethods, Version=2.0.11.0, Culture=neutral, PublicKeyToken=59b66d028979105b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Z.ExtensionMethods.2.0.11\lib\net40\Z.ExtensionMethods.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Caches\Tools.cs" />
@@ -81,6 +94,7 @@
     <Compile Include="Events\Statistic\MultipleEventHandlers.cs" />
     <Compile Include="Events\Statistic\PutTest.cs" />
     <Compile Include="Extensions.cs" />
+    <Compile Include="Logic\ToStringOrSerializedCacheKeyTest.cs" />
     <Compile Include="Logic\CacheKeyBaseReturnNullTest.cs" />
     <Compile Include="Logic\Scope\CacheKeyForComponentOverridingTest.cs" />
     <Compile Include="Logic\Scope\CacheKeyThatThrows.cs" />
@@ -137,6 +151,7 @@
     <Compile Include="TestData\ObjectWithMultipleParameters.cs" />
     <Compile Include="TestData\ObjectWithParameterReturningFixedValue.cs" />
     <Compile Include="TestData\ObjectWithOverloadedMethod.cs" />
+    <Compile Include="TestData\ObjectWithComplexProperties.cs" />
     <Compile Include="TestData\ObjectWithProperty.cs" />
     <Compile Include="TestData\ReturningRandomNumbers.cs" />
     <Compile Include="TestData\ObjectImplToString.cs" />

--- a/MbCacheTest/TestData/ObjectWithComplexProperties.cs
+++ b/MbCacheTest/TestData/ObjectWithComplexProperties.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace MbCacheTest.TestData
+{
+	public class ObjectWithComplexProperties
+	{
+		public string StringProp { get; set; } 
+		public double DoubleProp { get; set; } 
+		public IList<ObjectWithProperty> GenericListProp { get; set; } = new List<ObjectWithProperty>();
+	}
+}

--- a/MbCacheTest/packages.config
+++ b/MbCacheTest/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AutoFixture" version="3.50.2" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net40" />
   <package id="NUnit" version="3.5.0" targetFramework="net40" />
   <package id="SharpTestsEx" version="1.1.1" />
+  <package id="Z.ExtensionMethods" version="2.0.11" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Added a new parameters CacheKey type (ToStringOrSerializedCacheKey) for handling object where ToString is Suspicious (equals parameter's type name).  When it happends, the parameter's key is the object's serialized content.